### PR TITLE
remove duplicate image color space transform

### DIFF
--- a/mono/utils/do_test.py
+++ b/mono/utils/do_test.py
@@ -241,7 +241,7 @@ def do_scalecano_test_with_custom_data(
     dam_global = MetricAverageMeter(['abs_rel', 'rmse', 'silog', 'delta1', 'delta2', 'delta3'])
     
     for i, an in tqdm(enumerate(test_data)):
-        rgb_origin = cv2.imread(an['rgb'])[:, :, ::-1].copy()
+        rgb_origin = cv2.imread(an['rgb']).copy()
         if an['depth'] is not None:
             gt_depth = cv2.imread(an['depth'], -1)
             gt_depth_scale = an['depth_scale']


### PR DESCRIPTION
input image's color space has been transformed from https://github.com/YvanYin/Metric3D/blob/377e6c6642d0aca7aaa5a19e58fdcf5d0fd3d910/mono/utils/do_test.py#L244 before preprocess function at https://github.com/YvanYin/Metric3D/blob/377e6c6642d0aca7aaa5a19e58fdcf5d0fd3d910/mono/utils/do_test.py#L189

Maybe this is a small mistake:)